### PR TITLE
Make resilient to callbacks throwing exceptions

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,8 @@
+3.1
+===
+
+* Fix an issue where the gammu worker thread could be brought down if a callback throws an exception
+
 3.0
 ===
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ import subprocess
 import sys
 
 # some defines
-VERSION = '3.0'
+VERSION = '3.1'
 GAMMU_REQUIRED = '1.37.90'
 README_FILE = os.path.join(os.path.dirname(__file__), 'README.rst')
 with codecs.open(README_FILE, 'r', 'utf-8') as readme:


### PR DESCRIPTION
Gammu ReadDevice could (for example) execute a callback if an SMS message has been received, if this callback throws, it will bring the thread down and the worker will not work anymore.

This change address that by protecting the call to ReadDevice and execute the callback with the exception that was raised.
