### PR TITLE
Deprecate distutils

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 Installing
 ==========
 
-You can install in a usual way for Python modules using distutils, so use
+You can install in a usual way for Python modules using setuptools, so use
 ``setup.py`` which is placed in the top level directory::
 
     ./setup.py build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 codecov
 coverage
 coveralls
+packaging
 scrutinizer-ocular
 setuptools >= 38.6.0
 wheel >= 0.31.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ import os
 import platform
 import subprocess
 import sys
-from distutils.version import StrictVersion
+from packaging.version import parse
 
 from setuptools import Extension, setup
 
@@ -112,9 +112,9 @@ class GammuConfig:
         with open(self.config_path(self.path)) as handle:
             for line in handle:
                 if line.startswith("#define GAMMU_VERSION "):
-                    version = line.split('"')[1]
+                    version = parse(line.split('"')[1])
 
-        if version is None or StrictVersion(version) < StrictVersion(GAMMU_REQUIRED):
+        if version is None or version < parse(GAMMU_REQUIRED):
             print("Too old Gammu version, please upgrade!")
             sys.exit(100)
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ import os
 import platform
 import subprocess
 import sys
-from packaging.version import parse
 
+from packaging.version import parse
 from setuptools import Extension, setup
 
 # some defines


### PR DESCRIPTION
distutils has been deprecated in Python 3.10 and will be removed in Python 3.12

Remove mention of distutils in README.rst

Replace distutils.version.StrictVersion with packaging.version.parse and .Version