### PR TITLE
fix(config): validate configuration activation

### DIFF
--- a/gammu/src/gammu.c
+++ b/gammu/src/gammu.c
@@ -554,6 +554,20 @@ StateMachine_GetConfig(StateMachineObject *self, PyObject *args, PyObject *kwds)
         "UseGlobalDebugFile", Config->UseGlobalDebugFile);
 }
 
+static int
+StateMachine_ActivateConfig(StateMachineObject *self, int section)
+{
+    if (GSM_GetConfigNum(self->s) <= section) {
+        GSM_SetConfigNum(self->s, section + 1);
+        if (GSM_GetConfigNum(self->s) <= section) {
+            PyErr_Format(PyExc_ValueError, "Maximal configuration storage exceeded");
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 static char StateMachine_SetConfig__doc__[] =
 "SetConfig(Section, Values)\n\n"
 "Sets specified config section.\n\n"
@@ -688,8 +702,8 @@ StateMachine_SetConfig(StateMachineObject *self, PyObject *args, PyObject *kwds)
         }
     }
 
-    /* Tell Gammu we have configured another section */
-    GSM_SetConfigNum(self->s, section + 1);
+    if (!StateMachine_ActivateConfig(self, section))
+        return NULL;
 
     Py_RETURN_NONE;
 }
@@ -746,8 +760,10 @@ StateMachine_ReadConfig(StateMachineObject *self, PyObject *args, PyObject *kwds
     }
     Config->UseGlobalDebugFile = FALSE;
 
-    /* Tell Gammu we have configured another section */
-    GSM_SetConfigNum(self->s, dst + 1);
+    if (!StateMachine_ActivateConfig(self, dst)) {
+        INI_Free(cfg);
+        return NULL;
+    }
 
     INI_Free(cfg);
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -30,6 +30,28 @@ from .test_sms import PDU_DATA
 
 
 class ConfigTest(unittest.TestCase):
+    def test_config_sections(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "gammurc"
+            config_file.write_text(
+                "[gammu4]\nconnection = none\ndevice = /dev/null\n",
+                encoding="utf-8",
+            )
+
+            state_machine = gammu.StateMachine()
+            state_machine.ReadConfig(Section=4, Filename=str(config_file))
+            state_machine.SetConfig(0, state_machine.GetConfig(4))
+
+            cfg = state_machine.GetConfig(4)
+            assert cfg["Connection"] == "none"
+            assert cfg["Device"] == "/dev/null"
+
+            with pytest.raises(
+                ValueError,
+                match="Requested configuration not available",
+            ):
+                state_machine.GetConfig(100)
+
     def test_config_bool(self) -> None:
         state_machine = gammu.StateMachine()
         state_machine.SetConfig(


### PR DESCRIPTION
SetConfig and ReadConfig returned success when libGammu rejected the active configuration count, deferring the failure until initialization.

Closes gammu/gammu#414